### PR TITLE
46 date autodetection

### DIFF
--- a/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
+++ b/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
@@ -145,15 +145,16 @@ public class OCSVTransformer extends OAbstractTransformer {
           if (Character.isDigit(firstChar)) {
               // NUMBER
               if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
-                  fieldValue = Float.parseFloat(fieldStringValue);
+                  String numberAsString = fieldStringValue.replaceAll(",", ".");
+                  fieldValue = new Float(numberAsString);
                   if (!Float.isFinite((Float) fieldValue)) {
-                      fieldValue = Double.parseDouble(fieldStringValue);
+                      fieldValue = new Double(numberAsString);
                   }
               } else
                   try {
-                      fieldValue = Integer.parseInt(fieldStringValue);
+                      fieldValue = new Integer(fieldStringValue);
                   } catch (Exception e) {
-                      fieldValue = Long.parseLong(fieldStringValue);
+                      fieldValue = new Long(fieldStringValue);
                   }
           }
           else

--- a/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
+++ b/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
@@ -153,18 +153,22 @@ public class OCSVTransformer extends OAbstractTransformer {
                   fieldValue = df.parse(fieldStringValue);
               } catch (ParseException pe) {
                   // NUMBER
-                  if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
-                      String numberAsString = fieldStringValue.replaceAll(",", ".");
-                      fieldValue = new Float(numberAsString);
-                      if (!Float.isFinite((Float) fieldValue)) {
-                          fieldValue = new Double(numberAsString);
-                      }
-                  } else
-                      try {
-                          fieldValue = new Integer(fieldStringValue);
-                      } catch (Exception e) {
-                          fieldValue = new Long(fieldStringValue);
-                      }
+                  try {
+                      if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
+                          String numberAsString = fieldStringValue.replaceAll(",", ".");
+                          fieldValue = new Float(numberAsString);
+                          if (!Float.isFinite((Float) fieldValue)) {
+                              fieldValue = new Double(numberAsString);
+                          }
+                      } else
+                          try {
+                              fieldValue = new Integer(fieldStringValue);
+                          } catch (Exception e) {
+                              fieldValue = new Long(fieldStringValue);
+                          }
+                  } catch (NumberFormatException nf) {
+                      fieldValue = fieldStringValue;
+                  }
               }
           }
           else

--- a/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
+++ b/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
@@ -25,6 +25,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.OStringSerializerHelper;
 import com.orientechnologies.orient.etl.OETLProcessor;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -143,19 +146,26 @@ public class OCSVTransformer extends OAbstractTransformer {
           // DETERMINE THE TYPE
           final char firstChar = fieldStringValue.charAt(0);
           if (Character.isDigit(firstChar)) {
-              // NUMBER
-              if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
-                  String numberAsString = fieldStringValue.replaceAll(",", ".");
-                  fieldValue = new Float(numberAsString);
-                  if (!Float.isFinite((Float) fieldValue)) {
-                      fieldValue = new Double(numberAsString);
-                  }
-              } else
-                  try {
-                      fieldValue = new Integer(fieldStringValue);
-                  } catch (Exception e) {
-                      fieldValue = new Long(fieldStringValue);
-                  }
+              //DATE
+              DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+              df.setLenient(true);
+              try {
+                  fieldValue = df.parse(fieldStringValue);
+              } catch (ParseException pe) {
+                  // NUMBER
+                  if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
+                      String numberAsString = fieldStringValue.replaceAll(",", ".");
+                      fieldValue = new Float(numberAsString);
+                      if (!Float.isFinite((Float) fieldValue)) {
+                          fieldValue = new Double(numberAsString);
+                      }
+                  } else
+                      try {
+                          fieldValue = new Integer(fieldStringValue);
+                      } catch (Exception e) {
+                          fieldValue = new Long(fieldStringValue);
+                      }
+              }
           }
           else
             fieldValue = fieldStringValue;

--- a/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
+++ b/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
@@ -141,23 +141,24 @@ public class OCSVTransformer extends OAbstractTransformer {
         } else if (fieldStringValue != null && !fieldStringValue.isEmpty()) {
           // DETERMINE THE TYPE
           final char firstChar = fieldStringValue.charAt(0);
-          if (firstChar == stringCharacter)
-            // STRING
-            fieldValue = OStringSerializerHelper.getStringContent(fieldStringValue);
-          else if (Character.isDigit(firstChar))
-            // NUMBER
-            if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
-                fieldValue = Float.parseFloat(fieldStringValue);
-                if (!Float.isFinite((Float)fieldValue)) {
-                    fieldValue = Double.parseDouble(fieldStringValue);
-                }
-            }
-            else
-              try {
-                fieldValue = Integer.parseInt(fieldStringValue);
-              } catch (Exception e) {
-                fieldValue = Long.parseLong(fieldStringValue);
-              }
+          if (firstChar == stringCharacter) {
+              // STRING
+              fieldValue = OStringSerializerHelper.getStringContent(fieldStringValue);
+          }
+          else if (Character.isDigit(firstChar)) {
+              // NUMBER
+              if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
+                  fieldValue = Float.parseFloat(fieldStringValue);
+                  if (!Float.isFinite((Float) fieldValue)) {
+                      fieldValue = Double.parseDouble(fieldStringValue);
+                  }
+              } else
+                  try {
+                      fieldValue = Integer.parseInt(fieldStringValue);
+                  } catch (Exception e) {
+                      fieldValue = Long.parseLong(fieldStringValue);
+                  }
+          }
           else
             fieldValue = fieldStringValue;
 

--- a/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
+++ b/src/main/java/com/orientechnologies/orient/etl/transformer/OCSVTransformer.java
@@ -146,12 +146,12 @@ public class OCSVTransformer extends OAbstractTransformer {
             fieldValue = OStringSerializerHelper.getStringContent(fieldStringValue);
           else if (Character.isDigit(firstChar))
             // NUMBER
-            if (fieldStringValue.contains(".") || fieldStringValue.contains(","))
-              try {
+            if (fieldStringValue.contains(".") || fieldStringValue.contains(",")) {
                 fieldValue = Float.parseFloat(fieldStringValue);
-              } catch (Exception e) {
-                fieldValue = Double.parseDouble(fieldStringValue);
-              }
+                if (!Float.isFinite((Float)fieldValue)) {
+                    fieldValue = Double.parseDouble(fieldStringValue);
+                }
+            }
             else
               try {
                 fieldValue = Integer.parseInt(fieldStringValue);

--- a/src/test/java/com/orientechnologies/orient/etl/ETLBaseTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/ETLBaseTest.java
@@ -50,7 +50,7 @@ public abstract class ETLBaseTest extends TestCase {
   }
 
   protected List<ODocument> getResult() {
-    return ((TestLoader) proc.getLoader()).getResult();
+    return ((TestLoader) proc.getLoader()).loadedRecords;
   }
 
   protected void process(String cfgJson) {

--- a/src/test/java/com/orientechnologies/orient/etl/TestLoader.java
+++ b/src/test/java/com/orientechnologies/orient/etl/TestLoader.java
@@ -33,18 +33,14 @@ import java.util.List;
  * @author Luca Garulli on 27/11/14.
  */
 public class TestLoader extends OAbstractLoader {
-  private List<ODocument> result = new ArrayList<ODocument>();
+  public final List<ODocument> loadedRecords = new ArrayList<ODocument>();
 
   public TestLoader() {
   }
 
-  public List<ODocument> getResult() {
-    return result;
-  }
-
   @Override
   public void load(Object input, OCommandContext context) {
-    result.add((ODocument)input);
+    loadedRecords.add((ODocument) input);
   }
 
   @Override

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -104,7 +104,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(10.78f, Float.parseFloat(doc.field("firstDig").toString()));
+        assertEquals(10.78f, (Float)doc.field("firstDig"));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(minDouble, Double.parseDouble(doc.field("secondDig").toString()));
+        assertEquals(minDouble, (Double)doc.field("secondDig"));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(100, doc.field("number"));
+        assertEquals(new Integer(100), (Integer)doc.field("number"));
     }
     @Test
     public void testIntegerWithingQoutes() {
@@ -142,7 +142,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(100, Integer.parseInt(doc.field("number").toString()));
+        assertEquals(new Integer(100), (Integer)doc.field("number"));
     }
     @Test
     public void testLong() {
@@ -150,7 +150,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(3000000000l, doc.field("number"));
+        assertEquals(new Long(3000000000L), (Long)doc.field("number"));
     }
     @Test
     public void testLongWithingQoutes() {
@@ -158,6 +158,6 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(3000000000l, Long.parseLong(doc.field("number").toString()));
+        assertEquals(new Long(3000000000L), (Long)doc.field("number"));
     }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -90,12 +90,22 @@ public class OCSVTransformerTest extends ETLBaseTest {
     }
 
     @Test
-    public void testFloatDouble() {
-        String cfgJson = "{source: { content: { value: 'firstDig,secondDig\n10.78, \"888888888888888888878,9\"' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+    public void testFloat() {
+        String cfgJson = "{source: { content: { value: 'firstDig\n10.78,'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
         assertEquals(10.78f, doc.field("firstDig"));
-        assertEquals(888888888888888888878.9d, doc.field("secondDig"));
+    }
+
+    @Test
+    public void testDouble() {
+        Double minDouble =540282346638528870000000000000000000000.0d;
+
+        String cfgJson = "{source: { content: { value: 'secondDig\n540282346638528870000000000000000000000.0'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(minDouble, (Double)doc.field("secondDig"));
     }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -80,7 +80,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
     }
 
     @Test
-    public void testStringInDblQoutes() throws Exception {
+    public void testStringInDblQuotes() throws Exception {
         String cfgJson = "{source: { content: { value: 'text\n\"Hello, quotes are here!\"' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
@@ -99,8 +99,17 @@ public class OCSVTransformerTest extends ETLBaseTest {
     }
 
     @Test
-    public void testFloatWithinQoutes() {
+    public void testFloatWithinQuotes() {
         String cfgJson = "{source: { content: { value: 'firstNumber\n\"10.78\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(10.78f, (Float)doc.field("firstNumber"));
+    }
+
+    @Test
+    public void testFloatWithinQuotesAndCommaAsDecimalSeparator() {
+        String cfgJson = "{source: { content: { value: 'firstNumber\n\"10,78\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
@@ -125,6 +134,16 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
+        assertEquals(minDouble, (Double) doc.field("secondNumber"));
+    }
+    @Test
+    public void testDoubleWithingQuotesAndCommaAsDecimalSeparator() {
+        Double minDouble = 540282346638528870000000000000000000000.0d;
+
+        String cfgJson = "{source: { content: { value: 'secondNumber\n\"540282346638528870000000000000000000000,0\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
         assertEquals(minDouble, (Double)doc.field("secondNumber"));
     }
 
@@ -137,7 +156,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         assertEquals(new Integer(100), (Integer)doc.field("number"));
     }
     @Test
-    public void testIntegerWithingQoutes() {
+    public void testIntegerWithingQuotes() {
         String cfgJson = "{source: { content: { value: 'number\n\"100\"'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
@@ -153,7 +172,7 @@ public class OCSVTransformerTest extends ETLBaseTest {
         assertEquals(new Long(3000000000L), (Long)doc.field("number"));
     }
     @Test
-    public void testLongWithingQoutes() {
+    public void testLongWithingQuotes() {
         String cfgJson = "{source: { content: { value: 'number\n\"3000000000\"'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -74,8 +74,8 @@ public class OCSVTransformerTest extends ETLBaseTest {
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
         Date birthday = doc.field("BirthDay");
-        assertEquals(2008, birthday.getYear());
-        assertEquals(3, birthday.getMonth());
+        assertEquals(2008, birthday.getYear()+1900);
+        assertEquals(4, birthday.getMonth()+1);
         assertEquals(30, birthday.getDate());
     }
 

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -88,6 +88,15 @@ public class OCSVTransformerTest extends ETLBaseTest {
         String text = doc.field("text");
         assertEquals("Hello, quotes are here!", text);
     }
+    @Test
+    public void testStringStartedFromDigit() throws Exception {
+        String cfgJson = "{source: { content: { value: 'address\n\"401 Congress Ave, Suite 2450\"' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        String text = doc.field("address");
+        assertEquals("401 Congress Ave, Suite 2450", text);
+    }
 
     @Test
     public void testFloat() {

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -99,6 +99,15 @@ public class OCSVTransformerTest extends ETLBaseTest {
     }
 
     @Test
+    public void testFloatWithinQoutes() {
+        String cfgJson = "{source: { content: { value: 'firstDig\n\"10.78\",'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(10.78f, Float.parseFloat(doc.field("firstDig").toString()));
+    }
+
+    @Test
     public void testDouble() {
         Double minDouble =540282346638528870000000000000000000000.0d;
 
@@ -107,5 +116,48 @@ public class OCSVTransformerTest extends ETLBaseTest {
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
         assertEquals(minDouble, (Double)doc.field("secondDig"));
+    }
+    @Test
+    public void testDoubleWithingQuotes() {
+        Double minDouble = 540282346638528870000000000000000000000.0d;
+
+        String cfgJson = "{source: { content: { value: 'secondDig\n\"540282346638528870000000000000000000000.0\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(minDouble, Double.parseDouble(doc.field("secondDig").toString()));
+    }
+
+    @Test
+    public void testInteger() {
+        String cfgJson = "{source: { content: { value: 'number\n100'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(100, doc.field("number"));
+    }
+    @Test
+    public void testIntegerWithingQoutes() {
+        String cfgJson = "{source: { content: { value: 'number\n\"100\"'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(100, Integer.parseInt(doc.field("number").toString()));
+    }
+    @Test
+    public void testLong() {
+        String cfgJson = "{source: { content: { value: 'number\n3000000000'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(3000000000l, doc.field("number"));
+    }
+    @Test
+    public void testLongWithingQoutes() {
+        String cfgJson = "{source: { content: { value: 'number\n\"3000000000\"'} }, extractor : { row : {} }, transformers : [{ csv : {} }], loader : { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(3000000000l, Long.parseLong(doc.field("number").toString()));
     }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -91,41 +91,41 @@ public class OCSVTransformerTest extends ETLBaseTest {
 
     @Test
     public void testFloat() {
-        String cfgJson = "{source: { content: { value: 'firstDig\n10.78,'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        String cfgJson = "{source: { content: { value: 'firstNumber\n10.78'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(10.78f, doc.field("firstDig"));
+        assertEquals(10.78f, doc.field("firstNumber"));
     }
 
     @Test
     public void testFloatWithinQoutes() {
-        String cfgJson = "{source: { content: { value: 'firstDig\n\"10.78\",'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        String cfgJson = "{source: { content: { value: 'firstNumber\n\"10.78\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(10.78f, (Float)doc.field("firstDig"));
+        assertEquals(10.78f, (Float)doc.field("firstNumber"));
     }
 
     @Test
     public void testDouble() {
         Double minDouble =540282346638528870000000000000000000000.0d;
 
-        String cfgJson = "{source: { content: { value: 'secondDig\n540282346638528870000000000000000000000.0'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        String cfgJson = "{source: { content: { value: 'secondNumber\n540282346638528870000000000000000000000.0'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(minDouble, (Double)doc.field("secondDig"));
+        assertEquals(minDouble, (Double)doc.field("secondNumber"));
     }
     @Test
     public void testDoubleWithingQuotes() {
         Double minDouble = 540282346638528870000000000000000000000.0d;
 
-        String cfgJson = "{source: { content: { value: 'secondDig\n\"540282346638528870000000000000000000000.0\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        String cfgJson = "{source: { content: { value: 'secondNumber\n\"540282346638528870000000000000000000000.0\"'}  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        assertEquals(minDouble, (Double)doc.field("secondDig"));
+        assertEquals(minDouble, (Double)doc.field("secondNumber"));
     }
 
     @Test

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -78,4 +78,14 @@ public class OCSVTransformerTest extends ETLBaseTest {
         assertEquals(3, birthday.getMonth());
         assertEquals(30, birthday.getDate());
     }
+
+    @Test
+    public void testStringInDblQoutes() throws Exception {
+        String cfgJson = "{source: { content: { value: 'text\n\"Hello, quotes are here!\"' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        String text = doc.field("text");
+        assertEquals("Hello, quotes are here!", text);
+    }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -88,4 +88,14 @@ public class OCSVTransformerTest extends ETLBaseTest {
         String text = doc.field("text");
         assertEquals("Hello, quotes are here!", text);
     }
+
+    @Test
+    public void testFloatDouble() {
+        String cfgJson = "{source: { content: { value: 'firstDig,secondDig\n10.78, \"888888888888888888878,9\"' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        assertEquals(10.78f, doc.field("firstDig"));
+        assertEquals(888888888888888888878.9d, doc.field("secondDig"));
+    }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -22,6 +22,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.etl.ETLBaseTest;
 import org.junit.Test;
 
+import java.util.Date;
+import java.util.List;
+
 /**
  * Tests ETL CSV Transformer.
  *
@@ -64,4 +67,15 @@ public class OCSVTransformerTest extends ETLBaseTest {
       i++;
     }
   }
+    @Test
+    public void testDateTypeAutodetection(){
+        String cfgJson = "{source: { content: { value: 'BirthDay\n2008-04-30' }  }, extractor : { row: {} }, transformers : [{ csv: {} }], loader: { test: {} } }";
+        process(cfgJson);
+        List<ODocument> res = getResult();
+        ODocument doc = res.get(0);
+        Date birthday = doc.field("BirthDay");
+        assertEquals(2008, birthday.getYear());
+        assertEquals(3, birthday.getMonth());
+        assertEquals(30, birthday.getDate());
+    }
 }

--- a/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
+++ b/src/test/java/com/orientechnologies/orient/etl/transformer/OCSVTransformerTest.java
@@ -94,8 +94,8 @@ public class OCSVTransformerTest extends ETLBaseTest {
         process(cfgJson);
         List<ODocument> res = getResult();
         ODocument doc = res.get(0);
-        String text = doc.field("address");
-        assertEquals("401 Congress Ave, Suite 2450", text);
+        String address = doc.field("address");
+        assertEquals("401 Congress Ave, Suite 2450", address);
     }
 
     @Test


### PR DESCRIPTION
Processing DATE type auto-detection.

DATE format is: `yyyy-MM-dd`
For now TIME recognition is not implemented.
Also was fixed small issue with Double numbers and comma as decimal separator.
Improved test coverage.

All changes are backward compatible.